### PR TITLE
Allow scheme overriding

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -123,14 +123,19 @@ class Driver
     {
         $config = $this->configuration($name);
 
-        $container = new Container([
+        $options = [
             'driver' => [
                 'url' => $config['host'],
                 'login_id' => $config['login'],
                 'password' => $config['password'],
             ],
             'guzzle' => $config['guzzle']
-        ]);
+        ];
+        if (isset($config['scheme'])) {
+            $options['driver']['scheme'] = $config['scheme'];
+        }
+        
+        $container = new Container($options);
 
         $driver = new Mattermost($container);
         $driver->authenticate();


### PR DESCRIPTION
If using http instead https there's no way to set the scheme option because it's not propagated to the Driver instantiation.
A simple validation is added to verify if there's any scheme set.